### PR TITLE
Provide drush command and auth fallback to generate tokens

### DIFF
--- a/eloqua_api_redux.services.yml
+++ b/eloqua_api_redux.services.yml
@@ -2,6 +2,8 @@ services:
   eloqua_api_redux.client:
     class: Drupal\eloqua_api_redux\Service\EloquaApiClient
     arguments: ['@config.factory', '@logger.factory', '@cache.default']
+  eloqua_api_redux.auth_fallback_default:
+    class: Drupal\eloqua_api_redux\Service\EloquaAuthDefaultFallback
   eloqua_api_redux.contact:
     class: Drupal\eloqua_api_redux\Service\Contact
     arguments: ['@eloqua_api_redux.client']

--- a/modules/eloqua_api_auth_fallback/config/install/eloqua_api_auth_fallback.settings.yml
+++ b/modules/eloqua_api_auth_fallback/config/install/eloqua_api_auth_fallback.settings.yml
@@ -1,0 +1,3 @@
+sitename: ''
+username: ''
+password: ''

--- a/modules/eloqua_api_auth_fallback/config/schema/eloqua_api_auth_fallback.schema.yml
+++ b/modules/eloqua_api_auth_fallback/config/schema/eloqua_api_auth_fallback.schema.yml
@@ -1,6 +1,6 @@
 eloqua_api_auth_fallback.settings:
   type: config_object
-  label: 'Eloqua API Authentication settings'
+  label: 'Eloqua API resource owner password credentials settings'
   mapping:
     sitename:
       type: string

--- a/modules/eloqua_api_auth_fallback/config/schema/eloqua_api_auth_fallback.schema.yml
+++ b/modules/eloqua_api_auth_fallback/config/schema/eloqua_api_auth_fallback.schema.yml
@@ -1,0 +1,13 @@
+eloqua_api_auth_fallback.settings:
+  type: config_object
+  label: 'Eloqua API Authentication settings'
+  mapping:
+    sitename:
+      type: string
+      label: 'Site/Company Name'
+    username:
+      type: string
+      label: 'Username'
+    password:
+      type: string
+      label: 'Password'

--- a/modules/eloqua_api_auth_fallback/drush.services.yml
+++ b/modules/eloqua_api_auth_fallback/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  eloqua_api_auth_fallback.commands:
+    class: \Drupal\eloqua_api_auth_fallback\Commands\EloquaAuthTokensGenerate
+    arguments: ['@config.factory', '@logger.factory', '@eloqua_api_redux.client']
+    tags:
+      - { name: drush.command }

--- a/modules/eloqua_api_auth_fallback/eloqua_api_auth_fallback.info.yml
+++ b/modules/eloqua_api_auth_fallback/eloqua_api_auth_fallback.info.yml
@@ -1,0 +1,8 @@
+name: Eloqua API Auth Fallback
+description: Provides Eloqua API authentication using a resource owner password credentials grant as fallback to implicit grant.
+type: module
+package: Eloqua
+core: 8.x
+configure: eloqua_api_auth_fallback.settings
+dependecies:
+  - eloqua_api_redux:eloqua_api_redux

--- a/modules/eloqua_api_auth_fallback/eloqua_api_auth_fallback.links.menu.yml
+++ b/modules/eloqua_api_auth_fallback/eloqua_api_auth_fallback.links.menu.yml
@@ -1,5 +1,5 @@
 eloqua_api_auth_fallback.settings:
-  title: 'Eloqua API Authentication Settings'
-  route_name: eloqua_api_redux.settings
-  description: 'Configure Eloqua API Authentication Settings.'
+  title: 'Eloqua API resource owner password credentials'
+  route_name: eloqua_api_auth_fallback.settings
+  description: 'Configure Eloqua API resource owner password credentials.'
   parent: eloqua_api_redux.settings

--- a/modules/eloqua_api_auth_fallback/eloqua_api_auth_fallback.links.menu.yml
+++ b/modules/eloqua_api_auth_fallback/eloqua_api_auth_fallback.links.menu.yml
@@ -1,0 +1,5 @@
+eloqua_api_auth_fallback.settings:
+  title: 'Eloqua API Authentication Settings'
+  route_name: eloqua_api_redux.settings
+  description: 'Configure Eloqua API Authentication Settings.'
+  parent: eloqua_api_redux.settings

--- a/modules/eloqua_api_auth_fallback/eloqua_api_auth_fallback.routing.yml
+++ b/modules/eloqua_api_auth_fallback/eloqua_api_auth_fallback.routing.yml
@@ -2,6 +2,6 @@ eloqua_api_auth_fallback.settings:
   path: 'admin/config/services/eloqua_api_redux/auth_settings'
   defaults:
     _form:  '\Drupal\eloqua_api_auth_fallback\Form\Settings'
-    _title: 'Eloqua API Authentication Settings'
+    _title: 'Configure Eloqua API resource owner password credentials'
   requirements:
     _permission: 'administer eloqua api settings'

--- a/modules/eloqua_api_auth_fallback/eloqua_api_auth_fallback.routing.yml
+++ b/modules/eloqua_api_auth_fallback/eloqua_api_auth_fallback.routing.yml
@@ -1,0 +1,7 @@
+eloqua_api_auth_fallback.settings:
+  path: 'admin/config/services/eloqua_api_redux/auth_settings'
+  defaults:
+    _form:  '\Drupal\eloqua_api_auth_fallback\Form\Settings'
+    _title: 'Eloqua API Authentication Settings'
+  requirements:
+    _permission: 'administer eloqua api settings'

--- a/modules/eloqua_api_auth_fallback/eloqua_api_auth_fallback.services.yml
+++ b/modules/eloqua_api_auth_fallback/eloqua_api_auth_fallback.services.yml
@@ -1,0 +1,7 @@
+services:
+  eloqua_api_auth_fallback.auth_token_generate:
+    class: Drupal\eloqua_api_auth_fallback\Commands\EloquaAuthTokensGenerate
+    decorates: eloqua_api_redux.auth_fallback_default
+    decoration_priority: -10
+    public: false
+    arguments: ['@config.factory', '@logger.factory', '@eloqua_api_redux.client']

--- a/modules/eloqua_api_auth_fallback/src/Commands/EloquaAuthTokensGenerate.php
+++ b/modules/eloqua_api_auth_fallback/src/Commands/EloquaAuthTokensGenerate.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\eloqua_api_auth_fallback\Commands;
+
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\eloqua_api_redux\Service\EloquaApiClient;
+use Drush\Commands\DrushCommands;
+
+/**
+ * A drush command for eloqua api authentication module.
+ */
+class EloquaAuthTokensGenerate extends DrushCommands {
+
+  /**
+   * Immutable Config.
+   *
+   * @var \Drupal\Core\Config\Config|\Drupal\Core\Config\ImmutableConfig
+   */
+  protected $configSettings;
+
+  /**
+   * The logger factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
+
+  /**
+   * Eloqua API client service.
+   *
+   * @var \Drupal\eloqua_api_redux\Service\EloquaApiClient
+   */
+  protected $eloquaApiClient;
+
+  /**
+   * EloquaAuthTokensGenerate constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactory $config_factory
+   *   An instance of ConfigFactory.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   LoggerChannelFactoryInterface.
+   * @param \Drupal\eloqua_api_redux\Service\EloquaApiClient $eloqua_api_client
+   *   Eloqua API client service.
+   */
+  public function __construct(ConfigFactory $config_factory,
+                              LoggerChannelFactoryInterface $logger_factory,
+                              EloquaApiClient $eloqua_api_client) {
+    parent::__construct();
+    $this->configSettings = $config_factory->get('eloqua_api_auth_fallback.settings');
+    $this->loggerFactory = $logger_factory;
+    $this->eloquaApiClient = $eloqua_api_client;
+  }
+
+  /**
+   * Calls eloqua authentication API service to generate tokens.
+   *
+   * Access and refresh tokens are generated using resource owner password
+   * credentials grant method.
+   *
+   * @command eloqua_api_auth_fallback:generate-tokens
+   * @aliases eloqua-gt
+   * @usage eloqua_api_auth_fallback:generate-tokens
+   *   Calls eloqua authentication API and generate tokens
+   *   using Resource Owner Password Credentials grant.
+   */
+  public function generateTokens() {
+    $sitename = $this->configSettings->get('sitename');
+    $username = $this->configSettings->get('username');
+    $password = $this->configSettings->get('password');
+    if (empty($sitename) || empty($username) || empty($password)) {
+      $message = 'Eloqua authentication credentials are not set.';
+      $this->output()
+        ->writeln($message);
+      $this->loggerFactory->get('eloqua_api_auth_fallback')->error($message);
+      return FALSE;
+    }
+
+    $params = [
+      'grant_type' => 'password',
+      'scope' => 'full',
+      'username' => $sitename . '\\' . $username,
+      'password' => $password,
+    ];
+    $response = $this->eloquaApiClient->doTokenRequest($params);
+
+    if (!empty($response) && !empty($response['refresh_token'])) {
+      $message = 'Eloqua refresh and access tokens updated successfully.';
+      $this->output()
+        ->writeln($message);
+      $this->loggerFactory->get('eloqua_api_auth_fallback')->info($message);
+      return TRUE;
+    }
+    else {
+      $message = 'Error updating refresh and access tokens.';
+      $this->output()
+        ->writeln($message);
+      $this->loggerFactory->get('eloqua_api_auth_fallback')->error($message);
+    }
+
+    return FALSE;
+  }
+
+}

--- a/modules/eloqua_api_auth_fallback/src/Commands/EloquaAuthTokensGenerate.php
+++ b/modules/eloqua_api_auth_fallback/src/Commands/EloquaAuthTokensGenerate.php
@@ -6,11 +6,12 @@ use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\eloqua_api_redux\Service\EloquaApiClient;
 use Drush\Commands\DrushCommands;
+use Drupal\eloqua_api_redux\Service\EloquaAuthFallbackInterface;
 
 /**
- * A drush command for eloqua api authentication module.
+ * A drush command for eloqua api authentication using resource owner grants.
  */
-class EloquaAuthTokensGenerate extends DrushCommands {
+class EloquaAuthTokensGenerate extends DrushCommands implements EloquaAuthFallbackInterface {
 
   /**
    * Immutable Config.
@@ -63,8 +64,11 @@ class EloquaAuthTokensGenerate extends DrushCommands {
    * @usage eloqua_api_auth_fallback:generate-tokens
    *   Calls eloqua authentication API and generate tokens
    *   using Resource Owner Password Credentials grant.
+   *
+   * @return bool
+   *   TRUE if tokens are generated/renewed from eloqua API.
    */
-  public function generateTokens() {
+  public function generateTokensByResourceOwner() {
     $sitename = $this->configSettings->get('sitename');
     $username = $this->configSettings->get('username');
     $password = $this->configSettings->get('password');
@@ -90,12 +94,6 @@ class EloquaAuthTokensGenerate extends DrushCommands {
         ->writeln($message);
       $this->loggerFactory->get('eloqua_api_auth_fallback')->info($message);
       return TRUE;
-    }
-    else {
-      $message = 'Error updating refresh and access tokens.';
-      $this->output()
-        ->writeln($message);
-      $this->loggerFactory->get('eloqua_api_auth_fallback')->error($message);
     }
 
     return FALSE;

--- a/modules/eloqua_api_auth_fallback/src/Form/Settings.php
+++ b/modules/eloqua_api_auth_fallback/src/Form/Settings.php
@@ -4,6 +4,8 @@ namespace Drupal\eloqua_api_auth_fallback\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
 
 /**
  * Eloqua API Fallback Authentication Settings.
@@ -35,10 +37,20 @@ class Settings extends ConfigFormBase {
       '#title' => $this->t('Eloqua API resource owner password credentials'),
     ];
 
+    $form['credentials']['help'] = [
+      '#type' => '#markup',
+      '#markup' => $this->t('For more information on authenticate using a resource owner password credentials grant, refer this @link.',
+        [
+          '@link' => Link::fromTextAndUrl('https://docs.oracle.com/cloud/latest/marketingcs_gs/OMCAB/Developers/GettingStarted/Authentication/authenticate-using-oauth.htm#resource-owner-password-credentials-grant',
+            Url::fromUri('https://docs.oracle.com/cloud/latest/marketingcs_gs/OMCAB/Developers/GettingStarted/Authentication/authenticate-using-oauth.htm#resource-owner-password-credentials-grant'))->toString(),
+        ]),
+    ];
+
     $form['credentials']['sitename'] = [
       '#type' => 'textfield',
       '#required' => TRUE,
       '#title' => $this->t('Instance/Site Name'),
+      '#description' => $this->t('Site name is the company name you use to log in to Eloqua'),
       '#default_value' => $config->get('sitename'),
     ];
 
@@ -46,6 +58,7 @@ class Settings extends ConfigFormBase {
       '#type' => 'textfield',
       '#required' => TRUE,
       '#title' => $this->t('Username'),
+      '#description' => $this->t('Username you use to log in to Eloqua'),
       '#default_value' => $config->get('username'),
     ];
 
@@ -53,6 +66,7 @@ class Settings extends ConfigFormBase {
       '#type' => 'textfield',
       '#required' => TRUE,
       '#title' => $this->t('Password'),
+      '#description' => $this->t('Password you use to log in to Eloqua'),
       '#default_value' => $config->get('password'),
     ];
 

--- a/modules/eloqua_api_auth_fallback/src/Form/Settings.php
+++ b/modules/eloqua_api_auth_fallback/src/Form/Settings.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\eloqua_api_auth_fallback\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Eloqua API Fallback Authentication Settings.
+ */
+class Settings extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'eloqua_api_auth_fallback_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['eloqua_api_auth_fallback.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('eloqua_api_auth_fallback.settings');
+
+    $form['credentials'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Eloqua Instance Authentication Credentials'),
+    ];
+
+    $form['credentials']['sitename'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Instance/Site Name'),
+      '#default_value' => $config->get('sitename'),
+    ];
+
+    $form['credentials']['username'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Username'),
+      '#default_value' => $config->get('username'),
+    ];
+
+    $form['credentials']['password'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Password'),
+      '#default_value' => $config->get('password'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('eloqua_api_auth_fallback.settings')
+      ->set('sitename', $form_state->getValue('sitename'))
+      ->set('username', $form_state->getValue('username'))
+      ->set('password', $form_state->getValue('password'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/eloqua_api_auth_fallback/src/Form/Settings.php
+++ b/modules/eloqua_api_auth_fallback/src/Form/Settings.php
@@ -32,23 +32,26 @@ class Settings extends ConfigFormBase {
 
     $form['credentials'] = [
       '#type' => 'fieldset',
-      '#title' => $this->t('Eloqua Instance Authentication Credentials'),
+      '#title' => $this->t('Eloqua API resource owner password credentials'),
     ];
 
     $form['credentials']['sitename'] = [
       '#type' => 'textfield',
+      '#required' => TRUE,
       '#title' => $this->t('Instance/Site Name'),
       '#default_value' => $config->get('sitename'),
     ];
 
     $form['credentials']['username'] = [
       '#type' => 'textfield',
+      '#required' => TRUE,
       '#title' => $this->t('Username'),
       '#default_value' => $config->get('username'),
     ];
 
     $form['credentials']['password'] = [
       '#type' => 'textfield',
+      '#required' => TRUE,
       '#title' => $this->t('Password'),
       '#default_value' => $config->get('password'),
     ];

--- a/modules/eloqua_api_auth_fallback/src/Form/Settings.php
+++ b/modules/eloqua_api_auth_fallback/src/Form/Settings.php
@@ -39,9 +39,9 @@ class Settings extends ConfigFormBase {
 
     $form['credentials']['help'] = [
       '#type' => '#markup',
-      '#markup' => $this->t('For more information on authenticate using a resource owner password credentials grant, refer this @link.',
+      '#markup' => $this->t('For more information @link.',
         [
-          '@link' => Link::fromTextAndUrl('https://docs.oracle.com/cloud/latest/marketingcs_gs/OMCAB/Developers/GettingStarted/Authentication/authenticate-using-oauth.htm#resource-owner-password-credentials-grant',
+          '@link' => Link::fromTextAndUrl('refer to API Documentation for resource owner password credentials grant',
             Url::fromUri('https://docs.oracle.com/cloud/latest/marketingcs_gs/OMCAB/Developers/GettingStarted/Authentication/authenticate-using-oauth.htm#resource-owner-password-credentials-grant'))->toString(),
         ]),
     ];

--- a/src/Service/EloquaApiClient.php
+++ b/src/Service/EloquaApiClient.php
@@ -134,16 +134,16 @@ class EloquaApiClient {
       // If both access and refresh tokens are expired/invalid use fallback
       // method to generate access and refresh tokens using resource owner
       // password grant authorization.
-      // Also make sure that auth fallback service exists i.e. module that
-      // holds this service is enabled.
-      if (\Drupal::hasService('eloqua_api_auth_fallback.commands')) {
-        $tokenGeneratorService = \Drupal::service('eloqua_api_auth_fallback.commands');
-        $tokenGeneratorService->generateTokens();
-        if ($accessToken = $this->getEloquaApiCache('access_token')) {
+      // Also make sure that auth fallback service implementation exists.
+      $tokenGeneratorService = \Drupal::service('eloqua_api_redux.auth_fallback_default');
+      if ($tokenGeneratorService !== NULL) {
+        $response = $tokenGeneratorService->generateTokensByResourceOwner();
+        if ($response === TRUE && $accessToken = $this->getEloquaApiCache('access_token')) {
           return $accessToken;
         }
       }
-      $this->loggerFactory->get('eloqua_api_redux')->error("Refresh Token is expired, Update tokens by visiting Eloqua API settings page.");
+      $this->loggerFactory->get('eloqua_api_redux')
+        ->error("Refresh Token is expired, Update tokens by visiting Eloqua API settings page.");
     }
 
     return FALSE;

--- a/src/Service/EloquaAuthDefaultFallback.php
+++ b/src/Service/EloquaAuthDefaultFallback.php
@@ -3,7 +3,13 @@
 namespace Drupal\eloqua_api_redux\Service;
 
 /**
- * Interface for migrations.
+ * Class EloquaAuthDefaultFallback.
+ *
+ * Provides default implementation for eloqua auth fallback which needs
+ * to be overridden by module that implements the auth fallback e.g. using
+ * resource owner password grants.
+ *
+ * @package Drupal\eloqua_api_redux\Service
  */
 class EloquaAuthDefaultFallback implements EloquaAuthFallbackInterface {
 

--- a/src/Service/EloquaAuthDefaultFallback.php
+++ b/src/Service/EloquaAuthDefaultFallback.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\eloqua_api_redux\Service;
+
+/**
+ * Interface for migrations.
+ */
+class EloquaAuthDefaultFallback implements EloquaAuthFallbackInterface {
+
+  /**
+   * Default generateTokensByResourceOwner implementation.
+   *
+   * @inheritDoc
+   */
+  public function generateTokensByResourceOwner() {
+    return FALSE;
+  }
+
+}

--- a/src/Service/EloquaAuthFallbackInterface.php
+++ b/src/Service/EloquaAuthFallbackInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\eloqua_api_redux\Service;
+
+/**
+ * Interface for migrations.
+ */
+interface EloquaAuthFallbackInterface {
+
+  /**
+   * Calls eloqua authentication API service to generate tokens.
+   *
+   * Access and refresh tokens are generated using resource owner password
+   * credentials grant method.
+   *
+   * @return bool
+   *   TRUE if tokens are generated/renewed from eloqua API.
+   */
+  public function generateTokensByResourceOwner();
+
+}

--- a/src/Service/EloquaAuthFallbackInterface.php
+++ b/src/Service/EloquaAuthFallbackInterface.php
@@ -3,7 +3,7 @@
 namespace Drupal\eloqua_api_redux\Service;
 
 /**
- * Interface for migrations.
+ * Interface for elouqa auth fallback using resource owner password grant.
  */
 interface EloquaAuthFallbackInterface {
 

--- a/src/Service/EloquaAuthFallbackInterface.php
+++ b/src/Service/EloquaAuthFallbackInterface.php
@@ -4,6 +4,8 @@ namespace Drupal\eloqua_api_redux\Service;
 
 /**
  * Interface for elouqa auth fallback using resource owner password grant.
+ *
+ * @package Drupal\eloqua_api_redux\Service
  */
 interface EloquaAuthFallbackInterface {
 


### PR DESCRIPTION
Provide drush command and auth fallback to generate tokens
- https://www.drupal.org/project/eloqua_api_redux/issues/3053639
- Implement resource owner password grant authentication to generate access and refresh tokens and provide drush command for the same using auth fallback module
- Implement fallback for gerenrate access and refresh tokens when they are expired/invalidate