### PR TITLE
Fix typo in eloqua admin configuration route permissions string.

### DIFF
--- a/eloqua_api_redux.routing.yml
+++ b/eloqua_api_redux.routing.yml
@@ -4,7 +4,7 @@ eloqua_api_redux.settings:
     _form:  '\Drupal\eloqua_api_redux\Form\Settings'
     _title: 'Eloqua API Settings'
   requirements:
-    _permission: 'administer eloquia api settings'
+    _permission: 'administer eloqua api settings'
 
 eloqua_api_redux.callback:
   path: 'eloqua_api_redux/callback'


### PR DESCRIPTION
Small change to fix typo in eloqua admin configuration route permissions string.